### PR TITLE
Do not listen on HTTP by default

### DIFF
--- a/lib/smart_proxy_shellhooks/shellhooks.rb
+++ b/lib/smart_proxy_shellhooks/shellhooks.rb
@@ -1,12 +1,13 @@
 module Proxy::ShellHooks
-  #class NotFound < RuntimeError; end
-
   class Plugin < ::Proxy::Plugin
     plugin 'shellhooks', Proxy::ShellHooks::VERSION
 
     default_settings :directory => '/var/lib/foreman/shellhooks'
 
-    http_rackup_path File.expand_path('shellhooks_http_config.ru', File.expand_path('../', __FILE__))
+    # Listening via HTTP is only good for development
+    if ENV["FOREMAN_SHELLHOOKS_HTTP"]
+      http_rackup_path File.expand_path('shellhooks_http_config.ru', File.expand_path('../', __FILE__))
+    end
     https_rackup_path File.expand_path('shellhooks_http_config.ru', File.expand_path('../', __FILE__))
   end
 end

--- a/settings.d/shellhooks.yml.example
+++ b/settings.d/shellhooks.yml.example
@@ -1,6 +1,6 @@
 ---
-# always enable HTTPS only
-#:enabled: https
+# plugin only listens on https (http or both values will be ignored)
 :enabled: false
+
 # directory with executables
 :directory: /var/lib/foreman-proxy/shellhooks


### PR DESCRIPTION
Solution to the HTTP problem.

I still like to use HTTP for development, I wanted to create "i_know_better" setting but settings are not yet ready at this phase, so ENV variable instead.