### PR TITLE
Use rackup_path DSL method

### DIFF
--- a/lib/smart_proxy_shellhooks/shellhooks.rb
+++ b/lib/smart_proxy_shellhooks/shellhooks.rb
@@ -6,7 +6,6 @@ module Proxy::ShellHooks
 
     default_settings :directory => '/var/lib/foreman/shellhooks'
 
-    http_rackup_path File.expand_path('shellhooks_http_config.ru', File.expand_path('../', __FILE__))
-    https_rackup_path File.expand_path('shellhooks_http_config.ru', File.expand_path('../', __FILE__))
+    rackup_path File.expand_path('shellhooks_http_config.ru', __dir__)
   end
 end


### PR DESCRIPTION
In smart-proxy 2.3 the DSL method rackup_path was introduced. This is equivalent to calling both http_rackup_path and https_rackup_path with the same argument. It also uses the __dir__ method to simplify the code.