### PR TITLE
Redirect output of print_args script to stderr

### DIFF
--- a/examples/print_args
+++ b/examples/print_args
@@ -1,5 +1,5 @@
 #!/bin/sh
 #
-# Prints all arguments
+# Prints all arguments to stderr
 #
-echo "$@"
+echo "$@" >&2


### PR DESCRIPTION
Hello, I am currently working on improving documentation for foreman shellhooks. I am creating an example procedure on how to create a shellhook that runs the print_args script. If user wants to verify that the arguments were printed in the proxy logs, they first have to set the log level to DEBUG. This is an extra step which could be removed by redirecting output to stderr, which displays as WARNING in the logs. I am open to additional suggestions or opinions.